### PR TITLE
fix: adding the '--no-browser' option to control whether the generated report will be displayed in the browser

### DIFF
--- a/doxycheck/__init__.py
+++ b/doxycheck/__init__.py
@@ -398,6 +398,7 @@ def main():
     parser.add_argument("input", nargs='+', help="document or directory to validate")  # noqa: E501
     parser.add_argument("--doxygen-html", action="store_true", help="show doxygen html")  # noqa: E501
     parser.add_argument("--sphinx-html", action="store_true", help="show sphinx html")  # noqa: E501
+    parser.add_argument("--no-browser", action="store_true", help="don't show the generated html in the browser")  # noqa: E501
     args = parser.parse_args()
 
     colorama_init(autoreset=True)


### PR DESCRIPTION
**Context of change**: running the script over master branch, I got the following error:
```python
Traceback (most recent call last):
  File "/home/andre/dev/doxycheck/venv/bin/doxycheck", line 33, in <module>
    sys.exit(load_entry_point('doxycheck==0.0.1', 'console_scripts', 'doxycheck')())
  File "/home/andre/dev/doxycheck/venv/lib/python3.9/site-packages/doxycheck-0.0.1-py3.9.egg/doxycheck/__init__.py", line 408, in main
AttributeError: 'Namespace' object has no attribute 'no_browser'
```